### PR TITLE
refactor: private constructors for util classes and changing places of modifiers

### DIFF
--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -25,10 +25,10 @@ import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 
 public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 
-    final private ObjectMapper objectMapper;
-    final private IEventLogger logger;
+    private final ObjectMapper objectMapper;
+    private final IEventLogger logger;
     Objenesis objenesis = new ObjenesisStd(); // or ObjenesisSerializer
-    private Map<String, MockInstance> mockInstanceMap = new HashMap<>();
+    private final Map<String, MockInstance> mockInstanceMap = new HashMap<>();
 
     public AgentCommandExecutorImpl(ObjectMapper objectMapper, IEventLogger logger) {
         this.objectMapper = objectMapper;
@@ -430,15 +430,16 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 
             // try to get the instance of the class using Singleton.getInstance
             for (Method method : methods) {
-                if (method.getParameterCount() == 0 && Modifier.isStatic(method.getModifiers())) {
-                    if (method.getReturnType().equals(loadedClass)) {
-                        try {
-                            return method.invoke(null);
-                        } catch (InvocationTargetException ex) {
-                            // this method for potentially getting instance from static getInstance type method
-                            // did not work
-                        }
+                if (method.getParameterCount() == 0
+                        && Modifier.isStatic(method.getModifiers())
+                        && (method.getReturnType().equals(loadedClass))) {
+                    try {
+                        return method.invoke(null);
+                    } catch (InvocationTargetException ex) {
+                        // this method for potentially getting instance from static getInstance type method
+                        // did not work
                     }
+
                 }
             }
             throw new RuntimeException(e);

--- a/src/main/java/io/unlogged/Constants.java
+++ b/src/main/java/io/unlogged/Constants.java
@@ -2,5 +2,8 @@ package io.unlogged;
 
 
 public class Constants {
+
+    private Constants() {}
+
     public static final String AGENT_VERSION = "1.0.1";
 }

--- a/src/main/java/io/unlogged/Unlogged.java
+++ b/src/main/java/io/unlogged/Unlogged.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 public @interface Unlogged {
     /**
      * Comma separated list of package names which are to be included for recording
-     * @return List of strings, each one being a package name
+     * @return Array of strings, each one being a package name
      */
     String[] includePackage() default "";
 

--- a/src/main/java/io/unlogged/launch/AnnotationProcessor.java
+++ b/src/main/java/io/unlogged/launch/AnnotationProcessor.java
@@ -88,7 +88,7 @@ public class AnnotationProcessor extends AbstractProcessor {
     }
 
     public static class AstModificationNotifierData {
-        public volatile static boolean lombokInvoked = false;
+        public static volatile boolean lombokInvoked = false;
     }
 
 }

--- a/src/main/java/io/unlogged/logging/impl/DetailedEventStreamAggregatedLogger.java
+++ b/src/main/java/io/unlogged/logging/impl/DetailedEventStreamAggregatedLogger.java
@@ -68,7 +68,7 @@ public class DetailedEventStreamAggregatedLogger implements IEventLogger {
     //    private final ThreadLocal<ByteArrayOutputStream> threadOutputBuffer =
 //            ThreadLocal.withInitial(ByteArrayOutputStream::new);
     private final ThreadLocal<Boolean> isRecording = ThreadLocal.withInitial(() -> false);
-    final private boolean serializeValues = true;
+    private final boolean serializeValues = true;
     //    private final Map<String, WeaveLog> classMap = new HashMap<>();
 //    private final Map<Integer, DataInfo> callProbes = new HashMap<>();
     private final Set<Integer> probesToRecord = new HashSet<>();

--- a/src/main/java/io/unlogged/util/ClassTypeUtil.java
+++ b/src/main/java/io/unlogged/util/ClassTypeUtil.java
@@ -6,6 +6,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ClassTypeUtil {
+
+    private ClassTypeUtil() {}
+
     public static List<String> splitMethodDesc(String desc) {
         int beginIndex = desc.indexOf('(');
         int endIndex = desc.lastIndexOf(')');

--- a/src/main/java/io/unlogged/util/StreamUtil.java
+++ b/src/main/java/io/unlogged/util/StreamUtil.java
@@ -4,6 +4,9 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 public class StreamUtil {
+
+    private StreamUtil() {}
+
     public static final int BUFFER_SIZE = 8192;
 
     public static int copy(InputStream inputStream, OutputStream outputStream) throws IOException {

--- a/src/main/java/io/unlogged/weaver/TypeHierarchy.java
+++ b/src/main/java/io/unlogged/weaver/TypeHierarchy.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 public class TypeHierarchy {
 
-    final private Map<String, String> parentMap = new HashMap<>();
-    final private Map<String, String[]> interfaceMap = new HashMap<>();
+    private final Map<String, String> parentMap = new HashMap<>();
+    private final Map<String, String[]> interfaceMap = new HashMap<>();
     private final Names names;
     private final Symtab symtab;
     private Method loadClassMethod = null;


### PR DESCRIPTION
This PR handles the warnings of creating a private constructor for util classes and changing `final private ` to `private final` to maintain code consistency.
* Fixes issue #5  