### PR TITLE
Optimize Thread Safety and Performance in Logging System Through Concurrency Enhancements and Count Management Refactoring

### DIFF
--- a/src/main/java/io/unlogged/logging/perthread/FileEventCountThresholdChecker.java
+++ b/src/main/java/io/unlogged/logging/perthread/FileEventCountThresholdChecker.java
@@ -31,7 +31,7 @@ class FileEventCountThresholdChecker implements Runnable {
         Integer[] keySet = threadFileMap.keySet().toArray(new Integer[0]);
 //        errorLogger.log("started event count checker cron for threads: " + Arrays.toString(keySet));
         for (Integer theThreadId : keySet) {
-            int eventCount = threadEventCountProvider.getThreadEventCount(theThreadId).get();
+            int eventCount = threadEventCountProvider.getThreadEventCount(theThreadId);
             if (eventCount > 0) {
 //                errorLogger.log("thread [" + theThreadId + "] has [" + eventCount + "] events, flushing");
                 onExpiryRunner.apply(theThreadId);
@@ -43,7 +43,7 @@ class FileEventCountThresholdChecker implements Runnable {
         Integer[] keySet = threadFileMap.keySet().toArray(new Integer[0]);
 //        errorLogger.log("started event count checker cron for threads: " + Arrays.toString(keySet));
         for (Integer theThreadId : keySet) {
-            int eventCount = threadEventCountProvider.getThreadEventCount(theThreadId).get();
+            threadEventCountProvider.getThreadEventCount(theThreadId);
             onExpiryRunner.apply(theThreadId);
         }
     }

--- a/src/main/java/io/unlogged/logging/perthread/PerThreadBinaryFileAggregatedLogger.java
+++ b/src/main/java/io/unlogged/logging/perthread/PerThreadBinaryFileAggregatedLogger.java
@@ -282,39 +282,6 @@ public class PerThreadBinaryFileAggregatedLogger implements AggregatedFileLogger
 
     }
 
-    // dead code
-    public void writeNewException(byte[] exceptionBytes) {
-        if (1 < 2) {
-            return;
-        }
-        int bytesToWrite = 1 + 4 + exceptionBytes.length;
-
-        int currentThreadId = threadId.get();
-
-        try {
-            if (getThreadEventCount(currentThreadId) >= MAX_EVENTS_PER_FILE) {
-                prepareNextFile(currentThreadId);
-            }
-        } catch (IOException e) {
-            errorLogger.log(e);
-        }
-
-
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream(bytesToWrite);
-            DataOutputStream tempOut = new DataOutputStream(baos);
-            tempOut.writeByte(3);
-            tempOut.writeInt(exceptionBytes.length);
-            tempOut.write(exceptionBytes);
-            getStreamForThread(threadId.get()).write(baos.toByteArray());
-            getThreadEventCountinc(currentThreadId, 1);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-//        writeString(toString);
-        // System.err.println("Write new exception - 3," + toString.length() + " - " + toString + " = " + this.bytesWritten);
-    }
-
     public void writeEvent(int probeId, long valueId) {
         long timestamp = System.nanoTime();
         int currentThreadId = threadId.get();

--- a/src/main/java/io/unlogged/logging/perthread/PerThreadBinaryFileAggregatedLogger.java
+++ b/src/main/java/io/unlogged/logging/perthread/PerThreadBinaryFileAggregatedLogger.java
@@ -140,7 +140,7 @@ public class PerThreadBinaryFileAggregatedLogger implements AggregatedFileLogger
 
         if (count.containsKey(currentThreadId) && threadFileMap.get(currentThreadId) != null) {
             int eventCount = count.get(currentThreadId);
-            if (eventCount < MAX_EVENTS_PER_FILE) {
+            if (eventCount < 1) {
                 return;
             }
         }

--- a/src/main/java/io/unlogged/logging/perthread/RawFileCollector.java
+++ b/src/main/java/io/unlogged/logging/perthread/RawFileCollector.java
@@ -135,14 +135,12 @@ public class RawFileCollector implements Runnable {
         if (shutdownComplete) {
             return;
         }
-        boolean doneFinalize = false;
         try {
             UploadFile logFile = fileList.poll(1, TimeUnit.SECONDS);
             if (logFile == null) {
                 if (fileCount > 0 || shutdown) {
                     errorLogger.log(
                             "files from queue, currently [" + fileCount + "] files in list : shutdown: " + shutdown);
-                    doneFinalize = true;
                     finalizeArchiveAndUpload();
                     return;
                 }
@@ -170,9 +168,7 @@ public class RawFileCollector implements Runnable {
             errorLogger.log("finally check can archive [" + archivedIndexWriter.getArchiveFile()
                     .getName() + "]: " + archivedIndexWriter.fileCount() + " >= " + filesPerArchive);
             if (archivedIndexWriter.fileCount() >= filesPerArchive || shutdown) {
-                if (!doneFinalize) {
-                    finalizeArchiveAndUpload();
-                }
+                finalizeArchiveAndUpload();
             }
             if (shutdown) {
                 shutdownComplete = true;

--- a/src/main/java/io/unlogged/logging/perthread/ThreadEventCountProvider.java
+++ b/src/main/java/io/unlogged/logging/perthread/ThreadEventCountProvider.java
@@ -1,7 +1,5 @@
 package io.unlogged.logging.perthread;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public interface ThreadEventCountProvider {
-    AtomicInteger getThreadEventCount(int currentThreadId) ;
+    int getThreadEventCount(int currentThreadId) ;
 }

--- a/src/main/java/io/unlogged/logging/util/AggregatedFileLogger.java
+++ b/src/main/java/io/unlogged/logging/util/AggregatedFileLogger.java
@@ -8,8 +8,6 @@ public interface AggregatedFileLogger {
 
     void writeNewString(long id, String stringObject);
 
-    void writeNewException(byte[] toString);
-
     void writeEvent(int id, long value);
 
 

--- a/src/main/java/io/unlogged/logging/util/ObjectIdAggregatedStream.java
+++ b/src/main/java/io/unlogged/logging/util/ObjectIdAggregatedStream.java
@@ -97,7 +97,6 @@ public class ObjectIdAggregatedStream extends ObjectIdMap {
                     output.writeInt(e.getLineNumber());
 
                 }
-                aggregatedLogger.writeNewException(outputStream.toByteArray());
             } catch (Throwable e) {
                 // ignore all exceptions
             }


### PR DESCRIPTION
Key changes include:

1. **Replacing Synchronization with Concurrent Collections**: The `HashMap` instances in `PerThreadBinaryFileAggregatedLogger` are replaced with `ConcurrentHashMap`. This change implies an effort to improve the thread safety of the system without relying on explicit synchronization, which can be a performance bottleneck.

2. **Simplifying `getThreadEventCount` Method**: The `getThreadEventCount` method is simplified across several classes. It previously returned an `AtomicInteger` but now directly returns an `int`. This change suggests a shift in how thread event counts are managed, potentially optimizing the performance by reducing the overhead of atomic operations.

3. **Refactoring Count Management**: The management of thread event counts appears to be streamlined. Instead of using `AtomicInteger`, simple integers are now used, and a new method, `getThreadEventCountinc`, is introduced to increment these counts. This approach, combined with the use of concurrent collections, suggests an effort to balance thread safety with efficiency.

4. **Removal of Redundant Code**: Some redundant or unused code is removed, such as the `doneFinalize` variable in `RawFileCollector`, indicating a focus on code cleanliness and efficiency.
