### PR TITLE
This builds flow for injecting permanent mocks, in some cases where it was not happening earlier

### DIFF
--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -475,7 +475,6 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 	@Override
     public AgentCommandResponse injectMocks(AgentCommandRequest agentCommandRequest) throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, InstantiationException, NoSuchFieldException, SecurityException {
 
-		System.out.println("sdk_log: inside of inject mocks");
         int fieldCount = 0;
         int classCount = 0;
         Map<String, List<DeclaredMock>> mocksBySourceClass = agentCommandRequest

--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -473,7 +473,7 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
     }
 
     @Override
-    public AgentCommandResponse injectMocks(AgentCommandRequest agentCommandRequest) {
+    public AgentCommandResponse injectMocks(AgentCommandRequest agentCommandRequest) throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, InstantiationException {
 
         int fieldCount = 0;
         int classCount = 0;
@@ -484,6 +484,33 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
         for (String sourceClassName : mocksBySourceClass.keySet()) {
             Object sourceClassInstance = logger.getObjectByClassName(sourceClassName);
             if (sourceClassInstance == null) {
+				if (springBeanFactory != null) {
+					// inject from springBeanFactory
+					
+					// get list of bean names
+					// reflection: String[] beanNames = applicationContext.getBeanDefinitionNames()
+					Class<?> applicationContextClass = Class.forName("org.springframework.context.ApplicationContext");
+					Method getBeanDefinitionNamesMethod = applicationContextClass.getMethod("getBeanDefinitionNames");
+					String[] beanNames = (String[]) getBeanDefinitionNamesMethod.invoke(applicationContextClass.newInstance());
+
+					// get bean from beanName
+					List<Object> applicationBean = new ArrayList<>();
+					System.out.println("-------------------------------------");
+					for (String beanName: beanNames) {
+						// reflection: Object bean = applicationContext.getBean(beanName)
+						getBeanMethod = applicationContextClass.getMethod("getBean", Class.class);
+						Object bean = getBeanMethod.invoke(applicationContextClass, beanName);
+						applicationBean.add(bean);
+
+						// print values
+						System.out.println("beanName = " + beanName);
+						System.out.println("bean = " + bean.toString());
+					}
+					System.out.println("-------------------------------------");
+
+					// inject mocks
+					
+				}
                 // no instance found for this class
                 // nothing to inject mocks to
                 continue;

--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -524,12 +524,13 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 					Class<? extends Object> classDefination = null;
 					for (Object bean: applicationBean) {
 						if (classDefination == null ) {
-							Class<? extends Object> baseBeanClass = bean.getClass();
-							Class<? extends Object> beanClass = baseBeanClass;
+							Object baseBeanObject = bean;
+							Class<? extends Object> beanClass = bean.getClass();
 
 							while (beanClass != Object.class) {
 								if (sourceClassName.equals(beanClass.getName())) {
-									classDefination = baseBeanClass;
+									sourceClassInstance = baseBeanObject;
+									classDefination = baseBeanObject.getClass();
 									break;
 								}
 								beanClass = beanClass.getSuperclass();
@@ -537,30 +538,32 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 						}
 					}
 					classObject = classDefination;
+					System.out.println("log: classObject = " + classObject);
+					System.out.println("log: sourceClassInstance = " + sourceClassInstance);
 
 					// get a instance for classObject class
-					Constructor<?>[] constructors = classDefination.getDeclaredConstructors();
-					// check for a zero-args constructor
-					for (Constructor<?> constructor : constructors) {
-						if (constructor.getParameterCount() == 0) {
-							constructor.setAccessible(true);
-							sourceClassInstance = constructor.newInstance();
-						}
-					}
+					// Constructor<?>[] constructors = classDefination.getDeclaredConstructors();
+					// // check for a zero-args constructor
+					// for (Constructor<?> constructor : constructors) {
+					// 	if (constructor.getParameterCount() == 0) {
+					// 		constructor.setAccessible(true);
+					// 		sourceClassInstance = constructor.newInstance();
+					// 	}
+					// }
 
-					// If there is no zero-args constructor then build an instance from first constructor
-					if (sourceClassInstance == null) {
-						if (constructors.length > 0) {
-							Constructor<?> constructor = constructors[0];
-							// Define argument for the constructor (null for reference types, 0 for primitive types)
-							Object[] argsArray = new Object[constructor.getParameterCount()];
-							constructor.setAccessible(true);
-							sourceClassInstance = constructor.newInstance(argsArray);
-						} else {
-							// The class does not have any constructor
-							continue;
-						}
-					}
+					// // If there is no zero-args constructor then build an instance from first constructor
+					// if (sourceClassInstance == null) {
+					// 	if (constructors.length > 0) {
+					// 		Constructor<?> constructor = constructors[0];
+					// 		// Define argument for the constructor (null for reference types, 0 for primitive types)
+					// 		Object[] argsArray = new Object[constructor.getParameterCount()];
+					// 		constructor.setAccessible(true);
+					// 		sourceClassInstance = constructor.newInstance(argsArray);
+					// 	} else {
+					// 		// The class does not have any constructor
+					// 		continue;
+					// 	}
+					// }
 				}
 				else {
 					// no instance found for this class

--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -474,9 +474,7 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 			Class<? extends Object> classObject = null;
             if (sourceClassInstance == null) {
 
-				// define applicationContext and springBeanFactory
 				this.loadContext();
-
 				if (applicationContext != null) {
 					// get list of bean names
 					// reflection: String[] beanNames = applicationContext.getBeanDefinitionNames()
@@ -513,32 +511,6 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 						}
 					}
 					classObject = classDefination;
-					System.out.println("log: classObject = " + classObject);
-					System.out.println("log: sourceClassInstance = " + sourceClassInstance);
-
-					// get a instance for classObject class
-					// Constructor<?>[] constructors = classDefination.getDeclaredConstructors();
-					// // check for a zero-args constructor
-					// for (Constructor<?> constructor : constructors) {
-					// 	if (constructor.getParameterCount() == 0) {
-					// 		constructor.setAccessible(true);
-					// 		sourceClassInstance = constructor.newInstance();
-					// 	}
-					// }
-
-					// // If there is no zero-args constructor then build an instance from first constructor
-					// if (sourceClassInstance == null) {
-					// 	if (constructors.length > 0) {
-					// 		Constructor<?> constructor = constructors[0];
-					// 		// Define argument for the constructor (null for reference types, 0 for primitive types)
-					// 		Object[] argsArray = new Object[constructor.getParameterCount()];
-					// 		constructor.setAccessible(true);
-					// 		sourceClassInstance = constructor.newInstance(argsArray);
-					// 	} else {
-					// 		// The class does not have any constructor
-					// 		continue;
-					// 	}
-					// }
 				}
 				else {
 					// no instance found for this class

--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -475,6 +475,7 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
     @Override
     public AgentCommandResponse injectMocks(AgentCommandRequest agentCommandRequest) throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, InstantiationException {
 
+		System.out.println("sdk_log: inside of inject mocks");
         int fieldCount = 0;
         int classCount = 0;
         Map<String, List<DeclaredMock>> mocksBySourceClass = agentCommandRequest
@@ -483,34 +484,40 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
 
         for (String sourceClassName : mocksBySourceClass.keySet()) {
             Object sourceClassInstance = logger.getObjectByClassName(sourceClassName);
+			System.out.println("sdk_log: sourceClassName = " + sourceClassName);
+			System.out.println("sdk_log: sourceClassInstance = " + sourceClassInstance);
+
             if (sourceClassInstance == null) {
-				if (springBeanFactory != null) {
-					// inject from springBeanFactory
-					
-					// get list of bean names
-					// reflection: String[] beanNames = applicationContext.getBeanDefinitionNames()
-					Class<?> applicationContextClass = Class.forName("org.springframework.context.ApplicationContext");
-					Method getBeanDefinitionNamesMethod = applicationContextClass.getMethod("getBeanDefinitionNames");
-					String[] beanNames = (String[]) getBeanDefinitionNamesMethod.invoke(applicationContextClass.newInstance());
+				System.out.println("sdk_log: sourceClassInstance is null ");
+				System.out.println("sdk_log: springBeanFactory = " + springBeanFactory);
+				
+				// inject from springBeanFactory
+				
+				// get list of bean names
+				// reflection: String[] beanNames = applicationContext.getBeanDefinitionNames()
+				Class<?> applicationContextClass = Class.forName("org.springframework.context.ApplicationContext");
+				Method getBeanDefinitionNamesMethod = applicationContextClass.getMethod("getBeanDefinitionNames");
+				String[] beanNames = (String[]) getBeanDefinitionNamesMethod.invoke(applicationContextClass.newInstance());
 
-					// get bean from beanName
-					List<Object> applicationBean = new ArrayList<>();
-					System.out.println("-------------------------------------");
-					for (String beanName: beanNames) {
-						// reflection: Object bean = applicationContext.getBean(beanName)
-						getBeanMethod = applicationContextClass.getMethod("getBean", Class.class);
-						Object bean = getBeanMethod.invoke(applicationContextClass, beanName);
-						applicationBean.add(bean);
+				// get bean from beanName
+				List<Object> applicationBean = new ArrayList<>();
+				System.out.println("-------------------------------------");
+				for (String beanName: beanNames) {
+					// reflection: Object bean = applicationContext.getBean(beanName)
+					getBeanMethod = applicationContextClass.getMethod("getBean", Class.class);
+					Object bean = getBeanMethod.invoke(applicationContextClass, beanName);
+					applicationBean.add(bean);
 
-						// print values
-						System.out.println("beanName = " + beanName);
-						System.out.println("bean = " + bean.toString());
-					}
-					System.out.println("-------------------------------------");
-
-					// inject mocks
-					
+					// print values
+					System.out.println("beanName = " + beanName);
+					System.out.println("bean = " + bean.toString());
 				}
+				System.out.println("-------------------------------------");
+
+				// inject mocks
+
+
+
                 // no instance found for this class
                 // nothing to inject mocks to
                 continue;

--- a/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
+++ b/src/main/java/io/unlogged/AgentCommandExecutorImpl.java
@@ -134,20 +134,7 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
                 logger.setRecording(true);
             }
 
-            if (this.springTestContextManager == null) {
-                this.springTestContextManager = logger.getObjectByClassName("org.springframework.boot.web" +
-                        ".reactive.context" +
-                        ".AnnotationConfigReactiveWebServerApplicationContext");
-                setSpringApplicationContextAndLoadBeanFactory(this.springTestContextManager);
-            }
-
-            if (this.springTestContextManager == null) {
-                this.springTestContextManager = logger.getObjectByClassName(
-                        "org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext"
-                );
-                setSpringApplicationContextAndLoadBeanFactory(this.springTestContextManager);
-            }
-
+            this.loadContext();
             Object sessionInstance = tryOpenHibernateSessionIfHibernateExists();
 //            TestExecutionListener reactorContextTestExecutionListener = new ReactorContextTestExecutionListener();
 //            reactorContextTestExecutionListener.beforeTestMethod(null);
@@ -488,19 +475,7 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
             if (sourceClassInstance == null) {
 
 				// define applicationContext and springBeanFactory
-				if (this.springTestContextManager == null) {
-					this.springTestContextManager = logger.getObjectByClassName("org.springframework.boot.web" +
-							".reactive.context" +
-							".AnnotationConfigReactiveWebServerApplicationContext");
-					springBeanFactory = setSpringApplicationContextAndLoadBeanFactory(this.springTestContextManager);
-				}
-	
-				if (this.springTestContextManager == null) {
-					this.springTestContextManager = logger.getObjectByClassName(
-							"org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext"
-					);
-					springBeanFactory = setSpringApplicationContextAndLoadBeanFactory(this.springTestContextManager);
-				}
+				this.loadContext();
 
 				if (applicationContext != null) {
 					// get list of bean names
@@ -1670,6 +1645,23 @@ public class AgentCommandExecutorImpl implements AgentCommandExecutor {
                 .cast(getAutowireCapableBeanFactoryMethod.invoke(applicationContext));
         return springBeanFactory;
     }
+
+	private void loadContext() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		if (this.springTestContextManager == null) {
+			this.springTestContextManager = logger.getObjectByClassName("org.springframework.boot.web" +
+					".reactive.context" +
+					".AnnotationConfigReactiveWebServerApplicationContext");
+			setSpringApplicationContextAndLoadBeanFactory(this.springTestContextManager);
+		}
+
+		if (this.springTestContextManager == null) {
+			this.springTestContextManager = logger.getObjectByClassName(
+					"org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext"
+			);
+			setSpringApplicationContextAndLoadBeanFactory(this.springTestContextManager);
+		}
+	}
+
 
 
     public void enableSpringIntegration(Class<?> testClass) {


### PR DESCRIPTION
The build fixes issue-574.

## Approach
- The existence of both `applicationContext` and `springBeanFactory` is found.
- If `applicationContext` is null, no further action is taken.
- If `applicationContext` is not null, a reflection-based search is done to identify all beans.
- Subsequently, a search is performed through the bean hierarchy to find a match for the `sourceClassName`.
- Upon locating a matching class definition, all of its constructors are identified using reflection.
- If a `no-argument constructor` is present, an object is instantiated using it.
- In the absence of a `no-argument constructor`, the first available constructor is used, with default values.
- This instantiation process yields an object for the class in question.
- Following this, the mocking flow proceeds to inject the necessary values.