### PR TITLE
Updating cases for Unlogged-spring-maven-demo

### DIFF
--- a/src/test/python/replay_target.py
+++ b/src/test/python/replay_target.py
@@ -60,7 +60,8 @@ if __name__=="__main__":
 				ReplayTest("Handling characters case - a", TestResult.PASS),
 				ReplayTest("Case to test #624", TestResult.PASS),
 				ReplayTest("Case - 595", TestResult.PASS),
-				ReplayTest("StartsWith should be the assertion type - 590", TestResult.PASS)
+				ReplayTest("StartsWith should be the assertion type - 590", TestResult.PASS),
+				ReplayTest("Issue - 655 - Custom converter for model mapper", TestResult.PASS)
 			]
 		)
 	]

--- a/src/test/python/replay_target.py
+++ b/src/test/python/replay_target.py
@@ -61,7 +61,8 @@ if __name__=="__main__":
 				ReplayTest("Case to test #624", TestResult.PASS),
 				ReplayTest("Case - 595", TestResult.PASS),
 				ReplayTest("StartsWith should be the assertion type - 590", TestResult.PASS),
-				ReplayTest("Issue - 655 - Custom converter for model mapper", TestResult.PASS)
+				ReplayTest("Issue 655", TestResult.PASS),
+				ReplayTest("Issue 684", TestResult.PASS)
 			]
 		)
 	]


### PR DESCRIPTION
Adding a replay case to check if model mapper conversions handled with custom converters are handled correctly.