### PR TITLE
Modifying compile_target pipeline to run for other java versions: 11, 19, 21

### DIFF
--- a/.github/workflows/compile_target.yml
+++ b/.github/workflows/compile_target.yml
@@ -2,9 +2,9 @@ name: compile_target
 
 on:
   push:
-    branches: [main]
+    branches: [testing-akj]
   pull_request:
-    branches: [main]
+    branches: [testing-akj]
 
 jobs:
   build: 
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       # unlogged-sdk project
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK ${{ matrix.java-version == '8' && '11' || matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: ${{ matrix.java-version == '8' && '11' || matrix.java-version }}
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/.github/workflows/compile_target.yml
+++ b/.github/workflows/compile_target.yml
@@ -2,9 +2,9 @@ name: compile_target
 
 on:
   push:
-    branches: [testing-akj]
+    branches: [main]
   pull_request:
-    branches: [testing-akj]
+    branches: [main]
 
 jobs:
   build: 
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       # unlogged-sdk project
+      # setting JDK to 11 in case of java 8 project. For other projects JDK is set to project JDK
       - name: Set up JDK ${{ matrix.java-version == '8' && '11' || matrix.java-version }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/compile_target.yml
+++ b/.github/workflows/compile_target.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build: 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ '11', '19', '21' ]
 
     steps:
       # clone the unlogged-sdk project
@@ -16,10 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       # unlogged-sdk project
-      - name: Set up JDK 19
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          java-version: '19'
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
@@ -39,4 +42,4 @@ jobs:
           pip install -r ./src/test/python/requirements.txt
       - name: Run testing script
         run: |
-          python3 ./src/test/python/compile_target.py ${{ env.RELEASE_VERSION }}
+          python3 ./src/test/python/compile_target.py ${{ env.RELEASE_VERSION }} ${{ matrix.java-version }}

--- a/.github/workflows/compile_target.yml
+++ b/.github/workflows/compile_target.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '11', '19', '21' ]
+        java-version: ['8','11', '17', '21' ]
 
     steps:
       # clone the unlogged-sdk project

--- a/src/test/python/compile_target.py
+++ b/src/test/python/compile_target.py
@@ -50,7 +50,7 @@ def compile_target (target):
 	os.system("rm -rf " + target.test_repo_name)
 
 def convert_version_name_to_branch_name(version):
-    if version == '19':
+    if version == '17':
         return 'main'
     return f"java{version}"
 

--- a/src/test/python/compile_target.py
+++ b/src/test/python/compile_target.py
@@ -49,14 +49,20 @@ def compile_target (target):
 	# delete target
 	os.system("rm -rf " + target.test_repo_name)
 
+def convert_version_name_to_branch_name(version):
+    if version == '19':
+        return 'main'
+    return f"java{version}"
 
 if __name__=="__main__":
 
 	sdk_version = sys.argv[1]
+	java_branch_name = convert_version_name_to_branch_name(sys.argv[2])
+
 	target_list = [
 		#unlogged-spring-maven-demo
 		Target(
-			"https://github.com/unloggedio/unlogged-spring-maven-demo",
+			f"-b {java_branch_name} https://github.com/unloggedio/unlogged-spring-maven-demo",
 			"unlogged-spring-maven-demo",
 			"/pom.xml",
 			"/src/main/java/org/unlogged/demo/UnloggedDemoApplication.java",
@@ -64,7 +70,7 @@ if __name__=="__main__":
 			projectType="Normal"
 		),
 		Target(
-			"https://github.com/unloggedio/unlogged-spring-webflux-maven-demo",
+			f"-b {java_branch_name} https://github.com/unloggedio/unlogged-spring-webflux-maven-demo",
 			"unlogged-spring-webflux-maven-demo",
 			"/pom.xml",
 			"/src/main/java/org/unlogged/springwebfluxdemo/SpringWebfluxDemoApplication.java",


### PR DESCRIPTION
Modified the Git Action to test compile_target pipelines on multiple java versions.
Added support for java: 8, 11, 17, 21.
In case of java 8, unlogged sdk is set to java 11.

Testing:

1. Changed the on push and on pull targets to testing branch.
2. Pushed the code.
3. Tested the changes.

<img width="1431" alt="Screenshot 2024-05-16 at 5 53 20 PM" src="https://github.com/unloggedio/unlogged-sdk/assets/60289128/81555649-da5c-4a7c-9654-1c90eaeb8e1f">
