### PR TITLE
Fixes for frequency logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>unlogged-sdk</artifactId>
     <groupId>video.bug</groupId>
-    <version>0.6.2</version>
+    <version>0.6.94</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>unlogged-sdk</artifactId>
     <groupId>video.bug</groupId>
-    <version>0.6.94</version>
+    <version>0.6.99</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/io/unlogged/Constants.java
+++ b/src/main/java/io/unlogged/Constants.java
@@ -7,7 +7,7 @@ public class Constants {
 
 	// frequency logging 
 	public static final String mapStoreCompileValue = "unlogged$$mapStore";
-	public static final String probedValue = "$$Unlogged$Probed";
+	public static final String probedValue = "Unlogged$Probed$$";
 	
     private Constants() {
     }

--- a/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
@@ -1,5 +1,23 @@
 package io.unlogged.core.bytecode;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.commons.TryCatchBlockSorter;
+
 import io.unlogged.Constants;
 import io.unlogged.core.bytecode.method.JSRInliner;
 import io.unlogged.core.bytecode.method.MethodTransformer;
@@ -8,14 +26,6 @@ import io.unlogged.logging.util.TypeIdUtil;
 import io.unlogged.util.ProbeFlagUtil;
 import io.unlogged.weaver.TypeHierarchy;
 import io.unlogged.weaver.WeaveLog;
-
-import org.objectweb.asm.*;
-import org.objectweb.asm.commons.TryCatchBlockSorter;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 
 /**
  * This class weaves logging code into a Java class file.
@@ -264,7 +274,7 @@ public class ClassTransformer extends ClassVisitor {
 		}
 
 		this.methodList.add(name);
-		String nameProbed = name + Constants.probedValue;
+		String nameProbed = Constants.probedValue + name;
 		MethodVisitor methodVisitorProbed = super.visitMethod(access, nameProbed , desc, signature, exceptions);
 		methodVisitorProbed = addProbe(methodVisitorProbed, access, nameProbed, desc, exceptions);
 		

--- a/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
@@ -269,7 +269,7 @@ public class ClassTransformer extends ClassVisitor {
 		methodVisitorProbed = addProbe(methodVisitorProbed, access, nameProbed, desc, exceptions);
 		
 		long classCounter = getCounter(this.classCounterMap, className);
-		MethodVisitorWithoutProbe methodVisitorWithoutProbe = new MethodVisitorWithoutProbe(api, name, fullClassName, access, desc, classCounter, super.visitMethod(access, name , desc, signature, exceptions), this.unloggedProcessorConfig);
+		MethodVisitorWithoutProbe methodVisitorWithoutProbe = new MethodVisitorWithoutProbe(api, name, nameProbed, fullClassName, access, desc, classCounter, super.visitMethod(access, name , desc, signature, exceptions), this.unloggedProcessorConfig);
 
 		return new DualMethodVisitor(methodVisitorWithoutProbe, methodVisitorProbed);
     }

--- a/src/main/java/io/unlogged/core/bytecode/MethodVisitorWithoutProbe.java
+++ b/src/main/java/io/unlogged/core/bytecode/MethodVisitorWithoutProbe.java
@@ -20,14 +20,14 @@ class MethodVisitorWithoutProbe extends MethodVisitor {
 	private int access;
 	private UnloggedProcessorConfig unloggedProcessorConfig;
 
-	public MethodVisitorWithoutProbe(int api, String methodName, String fullClassName, int access, String desc, long classCounter, MethodVisitor mv, UnloggedProcessorConfig unloggedProcessorConfig) {
+	public MethodVisitorWithoutProbe(int api, String methodName, String nameProbed, String fullClassName, int access, String desc, long classCounter, MethodVisitor mv, UnloggedProcessorConfig unloggedProcessorConfig) {
 		super(api, mv);
 		this.methodName = methodName;
 		this.fullClassName = fullClassName;
 		this.access = access;
 		this.desc = desc;
 		this.classCounter = classCounter;
-		this.nameProbed = this.methodName + Constants.probedValue;
+		this.nameProbed = nameProbed;
 		this.unloggedProcessorConfig = unloggedProcessorConfig;
 	}
 

--- a/src/main/java/io/unlogged/core/bytecode/method/MethodTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/method/MethodTransformer.java
@@ -13,6 +13,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Stack;
+import io.unlogged.Constants;
 
 
 /**
@@ -89,6 +90,11 @@ public class MethodTransformer extends LocalVariablesSorter {
         this.sourceFileName = sourceFileName;
         // this.outerClassName = outerClassName; // not used
         this.access = access;
+
+		int suffixIndex = methodName.lastIndexOf(Constants.probedValue);
+		if (suffixIndex > 0) {
+			methodName = methodName.substring(0, suffixIndex);
+		}
         this.methodName = methodName;
         this.methodDesc = methodDesc;
 

--- a/src/main/java/io/unlogged/core/bytecode/method/MethodTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/method/MethodTransformer.java
@@ -91,10 +91,10 @@ public class MethodTransformer extends LocalVariablesSorter {
         // this.outerClassName = outerClassName; // not used
         this.access = access;
 
-		int suffixIndex = methodName.lastIndexOf(Constants.probedValue);
-		if (suffixIndex > 0) {
-			methodName = methodName.substring(0, suffixIndex);
-		}
+        int probedStringLength = Constants.probedValue.length();
+        if (methodName.length() > probedStringLength) {
+            methodName = methodName.substring(probedStringLength);
+        }
         this.methodName = methodName;
         this.methodDesc = methodDesc;
 


### PR DESCRIPTION
1. Scanning Issue
- Fixes the issue where probed methods had a suffix in there name.
- The methodName is defined to the original name in MethodTransformer. At line 156, when the call goes to weavingInfo(), It records records that original name as the name of method. This fixes the scanning issue, where the probed methods were not coming in live view.

2. Model Mapper was failing
- Method name are modified now by adding a prefix, that fixes the conflict in getter and setter names.
- This resolved ticket #70  