### PR TITLE
Modify the flow for adding the hash map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>unlogged-sdk</artifactId>
     <groupId>video.bug</groupId>
-    <version>0.6.3</version>
+    <version>0.6.6</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
@@ -244,10 +244,12 @@ public class ClassTransformer extends ClassVisitor {
 			this.hasStaticInitialiser = true;
 			MethodVisitor methodVisitorProbed = super.visitMethod(access, name, desc, signature, exceptions);
 
-			FieldVisitor fieldVisitor = visitField(Opcodes.ACC_STATIC, this.mapName, "Ljava/util/HashMap;", null, null);
-			fieldVisitor.visitEnd();
+			if (this.addHashMap) {
+				FieldVisitor fieldVisitor = visitField(Opcodes.ACC_STATIC, this.mapName, "Ljava/util/HashMap;", null, null);
+				fieldVisitor.visitEnd();
+				methodVisitorProbed = new InitStaticTransformer(methodVisitorProbed, fullClassName, this.methodList);
+			}
 
-			methodVisitorProbed = new InitStaticTransformer(methodVisitorProbed, fullClassName, this.methodList);
 			methodVisitorProbed = addProbe(methodVisitorProbed, access, name, desc, exceptions);
 			return methodVisitorProbed;
 		}


### PR DESCRIPTION
## Description of Bug
- This bug happens when a hashmap is added as a field and instantiated in the static method of an interface.

## Example of bug
1. Java code
- CrudController.java
```java
package org.unlogged.demo.controller.abstractions;

import org.springframework.web.bind.annotation.RequestBody;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RequestParam;

import java.util.List;

public interface CrudController<T, ID> {

    int localA = alpha.a;

    @RequestMapping("/find")
    public T findById(@RequestParam("id") ID id);

    @RequestMapping("/findAll")
    public List<T> findAll();

    @RequestMapping("/insert")
    public T insertNew(@RequestBody T payload);

    @RequestMapping("/update")
    public T update(@RequestBody T t);

    @RequestMapping("/delete")
    public T deleteById(@RequestParam("id") ID id);

    default int getAdd(int a, int b) {
        return a+b;
    }
}
```

2. Decompile code from SDK v0.6.5
```java
//
// Source code recreated from a .class file by IntelliJ IDEA
// (powered by FernFlower decompiler)
//

package org.unlogged.demo.controller.abstractions;

import io.unlogged.Runtime;
import io.unlogged.logging.Logging;
import java.util.HashMap;
import java.util.List;
import org.springframework.web.bind.annotation.RequestBody;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RequestParam;

public interface CrudController<T, ID> {
    int localA;
    HashMap org$unlogged$demo$controller$abstractions$CrudController$unlogged$$mapStore;

    @RequestMapping({"/find"})
    T findById(@RequestParam("id") ID id);

    @RequestMapping({"/findAll"})
    List<T> findAll();

    @RequestMapping({"/insert"})
    T insertNew(@RequestBody T payload);

    @RequestMapping({"/update"})
    T update(@RequestBody T t);

    @RequestMapping({"/delete"})
    T deleteById(@RequestParam("id") ID id);

    default int getAdd(int a, int b) {
        byte var3 = 0;

        try {
            Logging.recordEvent(this, 35095);
            Logging.recordEvent(a, 35096);
            Logging.recordEvent(b, 35097);
            Logging.recordEvent(35098);
            Logging.recordEvent(a, 35099);
            Logging.recordEvent(b, 35100);
            int var10000 = a + b;
            Logging.recordEvent(a + b, 35101);
            return var10000;
        } catch (Throwable var4) {
            Logging.recordEvent(var3, 35102);
            Logging.recordEvent(var4, 35103);
            Logging.recordEvent(var4, 35104);
            throw var4;
        }
    }

    static {
        Runtime.registerClass("eNqlVFtv0zAYNYW1E3thAsZ13C8pjFwc5zaWiWqAiDRtL9MeQY4voZObTGkG2k/gb/JHIJ7c1U1DB8KSFcvn+Jwv30kMAPgJAAiLMjNPclFkGaMmZaPCJEVelYUQrDRxOq5KTKphkY/NnfKE7pxj9dnrszvmEf6GlaQ1kbSkpDWVtHRJa06yu1eUIyzqleER7kM/iiCHtu07oZdy7DlhgBh3UGoj6iLiUTetuR92C0xZ+U4WQDb/w16OeOtgc1cqWQLnmbWfHjFSvU3et2xuz2/VAteam2eya+Cs4b3PAPy4+UsNZbmqnhN8DUzH63peqWcviQfj05xotFsa7ZI0bsjc1vCOktHxOxfgd+v1utKGLWXeU7g8+0ad7x6cHrM40Vj3FevyQta6Yi0pRjvrgWL16nm1peKHGr7S0pFHGt5t4F9q/PGCYCT+5OJgJO1pI5imzDNVXltjJf5c4R1VorT5tP89Z2X89x83Fsdf8cbHIRN0D49YjDdm2il9XigfGc0N5XP4rz6zP5FmKAqCxWDe9aVyncS8eh71ocYyFGupJWqJ9zV8pSXKVxquR92Zfg6gm7FqQKlkGUnST1Qkf7jXDBpG2GW2wzmExKeMeMTnYUBsB0XQS90Q+QQFPp1WAZa3iBjmw2pbdtnoyxdcXuDg1hdbxCOOEXN8xDDEGFOXcg8HEIYcOQxS6MDgN42+Md8=", "eNpjYOgUY2DolABiSSCWBWIFIFYCYnUg1gIAUS8FQA==");
        org$unlogged$demo$controller$abstractions$CrudController$unlogged$$mapStore = new HashMap();
        byte var0 = 0;

        try {
            Logging.recordEvent(35107);
            Logging.recordEvent(35108);
            int var10000 = alpha.a;
            Logging.recordEvent(var10000, 35109);
            Logging.recordEvent(var10000, 35110);
            localA = var10000;
            Logging.recordEvent(35111);
        } catch (Throwable var1) {
            Logging.recordEvent(var0, 35112);
            Logging.recordEvent(var1, 35113);
            Logging.recordEvent(var1, 35114);
            throw var1;
        }
    }
}
```

3. Decompile code from SDK v0.6.6
```java
//
// Source code recreated from a .class file by IntelliJ IDEA
// (powered by FernFlower decompiler)
//

package org.unlogged.demo.controller.abstractions;

import io.unlogged.Runtime;
import io.unlogged.logging.Logging;
import java.util.List;
import org.springframework.web.bind.annotation.RequestBody;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RequestParam;

public interface CrudController<T, ID> {
    int localA;

    @RequestMapping({"/find"})
    T findById(@RequestParam("id") ID id);

    @RequestMapping({"/findAll"})
    List<T> findAll();

    @RequestMapping({"/insert"})
    T insertNew(@RequestBody T payload);

    @RequestMapping({"/update"})
    T update(@RequestBody T t);

    @RequestMapping({"/delete"})
    T deleteById(@RequestParam("id") ID id);

    default int getAdd(int a, int b) {
        byte var3 = 0;

        try {
            Logging.recordEvent(this, 68037);
            Logging.recordEvent(a, 68038);
            Logging.recordEvent(b, 68039);
            Logging.recordEvent(68040);
            Logging.recordEvent(a, 68041);
            Logging.recordEvent(b, 68042);
            int var10000 = a + b;
            Logging.recordEvent(a + b, 68043);
            return var10000;
        } catch (Throwable var4) {
            Logging.recordEvent(var3, 68044);
            Logging.recordEvent(var4, 68045);
            Logging.recordEvent(var4, 68046);
            throw var4;
        }
    }

    static {
        Runtime.registerClass("eNqlVNlu1DAU9RQ6BSohKhBvvIE0FSWL42ylqRgVEJGq9qWad8fLMJUnqTIpqJ/FN7Dv+/I3YBd36smEKQhLVpJ7js+5uicJAK1HAICoKPvWfi6Kfp9Ri7JhYZEir8pCCFZaOBtVJSbVoMhH1ka5TzfGmDx7cbJi7eIHWEvaR5K2krSPJW1T0p6SbG8V5RALedfxCQ9gEMeQQ8cJ3MjPOPbdKESMuyhzEPUQ8amXSe6dzQJTVt5SDZDV/7BXK1nbWd1USrbAed/eznYZqW6mtxuK69MlKXChXjyUvQwOB37+KmidffxTL2259Psyxp+A43Vd7tNyL6RJd3SQE4P21KC1lHFN5pmBz2kZE39+Av5CPlzR2rChzZcaV2dv6PPtnYM9lqQG65VmnZrJeq1Z85rRzHqjWQtyn2vo+K2BLzZM5J2Bt2v4NYm/nxGMwj+cHIyifawFU5f5pNtrGqzCP2t8TreobO5tP8xZmfz9y43F3n28cnfABN3CQ5bglYlxKp8v2kdFc0n79P7VZ/IjMgxFQbDoTrt+1a5HMS+No+4ZrG+aNd8QtcK/G/hiQ5Q/DNyIWs1Uvw6y3mdVl1LF6qTpcqoj+cN/rUOjGHvMcTmHkASUEZ8EPAqJ46IY+pkXoYCgMKDjLgA4s0bEIB9U62rKneWeKs1w8OSPLeYxx4i5AWIYYoypR7mPQwgjjlwGKXRh+AuYWSxx", "eNpjYOQ8wsDIeQyIjwPxaSA+B8QXgPgqEN8AAGNHBrg=");
        byte var0 = 0;

        try {
            Logging.recordEvent(68049);
            Logging.recordEvent(68050);
            int var10000 = alpha.a;
            Logging.recordEvent(var10000, 68051);
            Logging.recordEvent(var10000, 68052);
            localA = var10000;
            Logging.recordEvent(68053);
        } catch (Throwable var1) {
            Logging.recordEvent(var0, 68054);
            Logging.recordEvent(var1, 68055);
            Logging.recordEvent(var1, 68056);
            throw var1;
        }
    }
}
```

## RCA
- The added field was declared with the static modifier. Java ensures that all fields of an interface be declared as public. Since, that was not the case with the hashmap field an error got thrown.

## Fix
- The hash map is not needed in the interface. So, it is not injected now.

## Test Plan
1. Compile [CI passing]
2. Replay [maven demo java 8]

- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/482a1552-5ddf-4343-b781-a418ad589816)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/2d093c86-66a0-4d04-b335-6e57c235e87b)

3. Replay [maven demo java 17]
- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/729c4a76-5e1f-46b7-8106-2168a6cbb6de)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/9518cce5-1a42-421e-8e1b-3e1355d439a8)

4. Replay [maven demo java 21] (tests modified)
- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/bb496c9e-94ac-4a26-a75a-161b9ed9fc1d)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/e3077999-fe7d-4366-834b-358873bdcc98)

5. Replay [webflux demo java 8]
- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/a9135903-60c6-409c-a91d-66c62002db35)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/6f9880df-bb0a-421f-a684-212973f5b363)

6. Replay [webflux demo java 11]
- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/5dede99d-6195-4da5-9150-19f607a072e3)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/5393a54e-c2bc-41a4-b1c8-1fb0bc183941)

7. Replay [webflux demo java 17]
- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/6534fcea-196a-4aed-a506-d73ed3885017)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/74d43df4-8729-40c0-a0fe-dbd0b3832a9d)

8. Replay [webflux demo java 21]
- SDK v0.6.5
![sdk-v0 6 5](https://github.com/unloggedio/unlogged-sdk/assets/147365133/5372fffa-19ed-45e0-9e28-c0947d47fc65)

- SDK v0.6.6
![sdk-v0 6 6](https://github.com/unloggedio/unlogged-sdk/assets/147365133/7aaad47b-dabb-43b4-8cef-dbb6e28b0c77)

9. Auto Executor [maven demo]
- SDK v0.6.5
```txt
Integration Mode ->
Total number of cases run : 442
Number of Passing cases : 416
Number of Failing cases : 26
Failing tests (Row numbers) : [50, 51, 53, 54, 93, 94, 100, 122, 123, 124, 125, 130, 131, 132, 133, 178, 179, 185, 186, 195, 196, 345, 346, 347, 352, 354]
Unit Mode ->
Total number of cases run : 334
Number of Passing cases : 320
Number of Failing cases : 14
Failing tests (Row numbers) : [28, 29, 31, 32, 100, 101, 110, 111, 163, 164, 173, 174, 319, 335]
```

- SDK v0.6.6
```txt
Integration Mode ->
Total number of cases run : 442
Number of Passing cases : 416
Number of Failing cases : 26
Failing tests (Row numbers) : [50, 51, 53, 54, 93, 94, 100, 122, 123, 124, 125, 130, 131, 132, 133, 178, 179, 185, 186, 195, 196, 345, 346, 347, 352, 354]
Unit Mode ->
Total number of cases run : 334
Number of Passing cases : 320
Number of Failing cases : 14
Failing tests (Row numbers) : [28, 29, 31, 32, 100, 101, 110, 111, 163, 164, 173, 174, 319, 335]
```

10. Auto Executor [webflux demo]
- SDK v0.6.5
```txt
Integration Mode ->
Total number of cases run : 626
Number of Passing cases : 512
Number of Failing cases : 114
Failing tests (Row numbers) : [8, 9, 10, 11, 34, 35, 36, 37, 38, 39, 50, 74, 76, 111, 112, 113, 114, 115, 116, 117, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 226, 227, 239, 240, 241, 243, 244, 245, 246, 286, 291, 293, 298, 299, 302, 303, 345, 346, 347, 348, 349, 350, 351, 352, 354, 355, 356, 357, 361, 365, 366, 367, 368, 389, 390, 391, 392, 393, 394, 396, 397, 398, 422, 423, 448, 552, 553, 554, 564, 565, 566, 568, 569, 570, 572, 573, 574, 576, 577, 578, 581, 582, 586, 588, 591, 594, 595, 596, 598, 599, 600, 601, 603, 604, 605, 608, 611, 616, 617, 618, 621, 624, 625, 627]
```

- SDK v0.6.6
```txt
Integration Mode ->
Total number of cases run : 626
Number of Passing cases : 512
Number of Failing cases : 114
Failing tests (Row numbers) : [8, 9, 10, 11, 34, 35, 36, 37, 38, 39, 50, 74, 76, 111, 112, 113, 114, 115, 116, 117, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 226, 227, 239, 240, 241, 243, 244, 245, 246, 286, 291, 293, 298, 299, 302, 303, 345, 346, 347, 348, 349, 350, 351, 352, 354, 355, 356, 357, 361, 365, 366, 367, 368, 389, 390, 391, 392, 393, 394, 396, 397, 398, 422, 423, 448, 552, 553, 554, 564, 565, 566, 568, 569, 570, 572, 573, 574, 576, 577, 578, 581, 582, 586, 588, 591, 594, 595, 596, 598, 599, 600, 601, 603, 604, 605, 608, 611, 616, 617, 618, 621, 624, 625, 627]
```

11. UI test (flaky run)
<img width="1437" alt="1" src="https://github.com/unloggedio/unlogged-sdk/assets/147365133/6fae46cc-076d-4690-831a-df5044e7cf70">
<img width="1428" alt="2" src="https://github.com/unloggedio/unlogged-sdk/assets/147365133/eddc3a17-a52b-408f-9b04-517b8f2ca66d">

