### PR TITLE
Fix recursive method call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>unlogged-sdk</artifactId>
     <groupId>video.bug</groupId>
-    <version>0.6.6</version>
+    <version>0.6.7</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
@@ -16,7 +16,6 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.TypePath;
 import org.objectweb.asm.commons.TryCatchBlockSorter;
 
-import io.unlogged.Constants;
 import io.unlogged.core.bytecode.method.JSRInliner;
 import io.unlogged.core.bytecode.method.MethodTransformer;
 import io.unlogged.core.processor.UnloggedProcessorConfig;
@@ -52,6 +51,7 @@ public class ClassTransformer extends ClassVisitor {
 	private boolean addHashMap = true;
 	private UnloggedProcessorConfig unloggedProcessorConfig;
 	private String mapName;
+	private String probedMethodPrefix;
 
     /**
      * This constructor weaves the given class and provides the result.
@@ -183,6 +183,7 @@ public class ClassTransformer extends ClassVisitor {
                       String superName, String[] interfaces) {
 //		System.err.println("Visit class ["+ name + "]");
         this.fullClassName = name;
+		this.probedMethodPrefix = DistinctClassLogNameMap.getProbedMethodPrefix(fullClassName);
 		this.mapName = DistinctClassLogNameMap.getClassMapStore(fullClassName);
         this.weavingInfo.setFullClassName(fullClassName);
         int index = name.lastIndexOf(PACKAGE_SEPARATOR);
@@ -269,7 +270,7 @@ public class ClassTransformer extends ClassVisitor {
 
 		String methodCompoundName = DistinctClassLogNameMap.getMethodCompoundName(name, desc);
 		this.methodList.add(methodCompoundName);
-		String nameProbed = Constants.probedValue + name;
+		String nameProbed = this.probedMethodPrefix + name;
 		MethodVisitor methodVisitorProbed = super.visitMethod(access, nameProbed , desc, signature, exceptions);
 		methodVisitorProbed = addProbe(methodVisitorProbed, access, nameProbed, desc, exceptions);
 		

--- a/src/main/java/io/unlogged/core/bytecode/method/MethodTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/method/MethodTransformer.java
@@ -3,6 +3,7 @@ package io.unlogged.core.bytecode.method;
 import com.insidious.common.weaver.Descriptor;
 import com.insidious.common.weaver.EventType;
 import io.unlogged.core.bytecode.WeaveConfig;
+import io.unlogged.util.DistinctClassLogNameMap;
 import io.unlogged.weaver.WeaveLog;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.LocalVariablesSorter;
@@ -13,7 +14,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Stack;
-import io.unlogged.Constants;
 
 
 /**
@@ -91,7 +91,7 @@ public class MethodTransformer extends LocalVariablesSorter {
         // this.outerClassName = outerClassName; // not used
         this.access = access;
 
-        int probedStringLength = Constants.probedValue.length();
+        int probedStringLength = DistinctClassLogNameMap.getProbedMethodPrefix(className).length();
         if (methodName.length() > probedStringLength) {
             methodName = methodName.substring(probedStringLength);
         }

--- a/src/main/java/io/unlogged/util/DistinctClassLogNameMap.java
+++ b/src/main/java/io/unlogged/util/DistinctClassLogNameMap.java
@@ -13,4 +13,10 @@ public class DistinctClassLogNameMap {
 		String methodCompoundName = name + "$" + desc;
 		return methodCompoundName;
 	}
+
+	public static String getProbedMethodPrefix(String fullClassName) {
+		String fullClassPart = fullClassName.replace("/", "$");
+		String classPrefix = Constants.probedValue + fullClassPart + "$";
+		return classPrefix;
+	}
 }


### PR DESCRIPTION
Injected probe methods now have a prefix to them, that is based on the fully qualified class name of there owner class. This ensures that java does not calls method of other classes.

This can happen even when decompiled class files show that the method being called is of the correct class.

## Fix Video
- SDK v0.6.6
https://drive.google.com/file/d/1xU2JvsgIMGPwBEuvRPgDzjJSTMSdd3Q4/view?usp=sharing

- SDK v0.6.7
https://drive.google.com/file/d/1pSnDp9y-tD6xzvsdFOslfIM43ok9tToe/view?usp=sharing

## Test Plan
1. Compile pipeline
- CI passing


2. Replay pipeline
- SDK 0.6.7
<img width="596" alt="Screenshot 2024-07-12 at 7 26 19 PM" src="https://github.com/user-attachments/assets/f4c4faf5-1638-4ec3-8640-e6b407ef29b7">
