### PR TITLE
Adding a Job summary/Report for AutoExecutor runs

### DIFF
--- a/.github/workflows/auto_execute_target.yml
+++ b/.github/workflows/auto_execute_target.yml
@@ -50,7 +50,7 @@ jobs:
         if: always()
         run: |
           echo "# AutoExecutor CI results" >> $GITHUB_STEP_SUMMARY
-          echo "**SDK version** : ${{ env.RELEASE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "**SDK version** : `${{ env.RELEASE_VERSION }}`" >> $GITHUB_STEP_SUMMARY
 
       - name: Read maven-demo's markdown report
         id: maventest

--- a/.github/workflows/auto_execute_target.yml
+++ b/.github/workflows/auto_execute_target.yml
@@ -50,7 +50,7 @@ jobs:
         if: always()
         run: |
           echo "# AutoExecutor CI results" >> $GITHUB_STEP_SUMMARY
-          echo "**SDK version** : `${{ env.RELEASE_VERSION }}`" >> $GITHUB_STEP_SUMMARY
+          echo "**SDK version** : ${{ env.RELEASE_VERSION }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Read maven-demo's markdown report
         id: maventest

--- a/.github/workflows/auto_execute_target.yml
+++ b/.github/workflows/auto_execute_target.yml
@@ -45,3 +45,30 @@ jobs:
           name: AutoExecutorReports
           path: |
             **/target/test-classes/auto-test-resources/AutoExecutorReports/
+
+      - name: Summarize Job summary - start
+        if: always()
+        run: |
+          echo "# AutoExecutor CI results" >> $GITHUB_STEP_SUMMARY
+          echo "**SDK version** : ${{ env.RELEASE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Read maven-demo's markdown report
+        id: maventest
+        uses: jaywcjlove/github-action-read-file@main
+        with:
+          localfile: target/test-classes/unlogged-spring-maven-demo-summary.md
+        if: always()
+
+      - name: Read webflux-demo's markdown report
+        id: webfluxtest
+        uses: jaywcjlove/github-action-read-file@main
+        with:
+          localfile: target/test-classes/unlogged-spring-maven-demo-summary.md
+        if: always()
+
+      - name: Add report contents
+        run: |
+          echo "${{ steps.maventest.outputs.content }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.webfluxtest.outputs.content }}" >> $GITHUB_STEP_SUMMARY
+        if: always()
+

--- a/.github/workflows/auto_execute_target.yml
+++ b/.github/workflows/auto_execute_target.yml
@@ -56,14 +56,14 @@ jobs:
         id: maventest
         uses: jaywcjlove/github-action-read-file@main
         with:
-          localfile: target/test-classes/unlogged-spring-maven-demo-summary.md
+          localfile: target/test-classes/auto-test-resources/AutoExecutorReports/unlogged-spring-maven-demo-summary.md
         if: always()
 
       - name: Read webflux-demo's markdown report
         id: webfluxtest
         uses: jaywcjlove/github-action-read-file@main
         with:
-          localfile: target/test-classes/unlogged-spring-maven-demo-summary.md
+          localfile: target/test-classes/auto-test-resources/AutoExecutorReports/unlogged-spring-webflux-maven-demo-summary.md
         if: always()
 
       - name: Add report contents

--- a/src/test/java/io/unlogged/autoexecutor/AutoExecutorCITest.java
+++ b/src/test/java/io/unlogged/autoexecutor/AutoExecutorCITest.java
@@ -91,8 +91,8 @@ public class AutoExecutorCITest {
         AgentClientLite agentClientLite = new AgentClientLite();
         boolean isConnected = agentClientLite.isConnected();
         if (!isConnected) {
-            System.out.println("Skipping : Agent not connected");
             logger.info("Skipping autoExecutor Run, Agent not connected");
+            MarkdownReportGenerator.generateReportForSkippedTest(testconfig.getProjectId(), getReportsPath());
             return;
         }
 

--- a/src/test/java/io/unlogged/autoexecutor/AutoExecutorCITest.java
+++ b/src/test/java/io/unlogged/autoexecutor/AutoExecutorCITest.java
@@ -1,10 +1,12 @@
 package io.unlogged.autoexecutor;
 
+import io.unlogged.autoexecutor.report.MarkdownReportGenerator;
 import io.unlogged.autoexecutor.testutils.autoCIUtils.AgentClientLite;
 import io.unlogged.autoexecutor.testutils.autoCIUtils.AssertionUtils;
 import io.unlogged.autoexecutor.testutils.autoCIUtils.ParseUtils;
 import io.unlogged.autoexecutor.testutils.autoCIUtils.XlsxUtils;
 import io.unlogged.autoexecutor.testutils.entity.AutoAssertionResult;
+import io.unlogged.autoexecutor.testutils.entity.TestConfig;
 import io.unlogged.autoexecutor.testutils.entity.TestResultSummary;
 import io.unlogged.autoexecutor.testutils.entity.TestUnit;
 import io.unlogged.command.AgentCommand;
@@ -33,12 +35,16 @@ public class AutoExecutorCITest {
     private final Logger logger = Logger.getLogger("AutoExecutorLog");
     private FileHandler fh;
     final private String testResourcesPath = "auto-test-resources/";
+    final private String testReportsPath = "AutoExecutorReports/";
     final private boolean printOnlyFailing = false;
 
+    private String getReportsPath() {
+        return Thread.currentThread().getContextClassLoader()
+                .getResource(testResourcesPath).getPath() + testReportsPath;
+    }
+
     private void setupLogger(String project) {
-        String autoExecutorResourcesPath = Thread.currentThread().getContextClassLoader()
-                .getResource(testResourcesPath).getPath();
-        String reportsPath = autoExecutorResourcesPath + "AutoExecutorReports/";
+        String reportsPath = getReportsPath();
         new File(reportsPath).mkdirs();
         try {
             fh = new FileHandler(reportsPath + project + "_report.txt", true);
@@ -54,6 +60,7 @@ public class AutoExecutorCITest {
     //mvn test -Dtest=AutoExecutorCITest#startUnloggedMavenDemoTest
     @Test
     public void startUnloggedMavenDemoTest() {
+        String projectId = "unlogged-spring-maven-demo";
         TreeMap<String, URL> testConfig = new TreeMap<>();
         URL pathToIntegrationResources = Thread.currentThread().getContextClassLoader()
                 .getResource(testResourcesPath + "maven-demo-integration-resources.xlsx");
@@ -61,13 +68,14 @@ public class AutoExecutorCITest {
                 .getResource(testResourcesPath + "maven-demo-mocked-resources.xlsx");
         testConfig.put("Integration", pathToIntegrationResources);
         testConfig.put("Unit", pathToMockResources);
-        setupLogger("unlogged-spring-maven-demo");
-        runTests(testConfig);
+        setupLogger(projectId);
+        runTests(new TestConfig(projectId, testConfig));
     }
 
     //mvn test -Dtest=AutoExecutorCITest#startWebfluxDemoTest
     @Test
     public void startWebfluxDemoTest() {
+        String projectId = "unlogged-spring-webflux-maven-demo";
         TreeMap<String, URL> testConfig = new TreeMap<>();
         URL pathToIntegrationResources = Thread.currentThread().getContextClassLoader()
                 .getResource(testResourcesPath + "webflux-demo-integration-resources.xlsx");
@@ -75,12 +83,11 @@ public class AutoExecutorCITest {
                 .getResource(testResourcesPath + "webflux-demo-unit-resources.xlsx");
         testConfig.put("Integration", pathToIntegrationResources);
         testConfig.put("Unit", pathToMockResources);
-        setupLogger("unlogged-spring-webflux-maven-demo");
-        runTests(testConfig);
+        setupLogger(projectId);
+        runTests(new TestConfig(projectId, testConfig));
     }
 
-
-    public void runTests(TreeMap<String, URL> testConfigs) {
+    public void runTests(TestConfig testconfig) {
         AgentClientLite agentClientLite = new AgentClientLite();
         boolean isConnected = agentClientLite.isConnected();
         if (!isConnected) {
@@ -91,9 +98,9 @@ public class AutoExecutorCITest {
 
         List<TestResultSummary> resultSummaries = new ArrayList<>();
 
-        for (String testMode : testConfigs.keySet()) {
+        for (String testMode : testconfig.getModeToResourceMap().keySet()) {
             logger.info("\n-----" + testMode + " mode testing-----\n");
-            TestResultSummary summary = executeMethods(testConfigs.get(testMode), agentClientLite);
+            TestResultSummary summary = executeMethods(testconfig.getModeToResourceMap().get(testMode), agentClientLite);
             summary.setMode(testMode);
             resultSummaries.add(summary);
         }
@@ -109,6 +116,7 @@ public class AutoExecutorCITest {
                 overallStatus = false;
             }
         }
+        MarkdownReportGenerator.generateAndWriteMarkdownReport(testconfig.getProjectId(), getReportsPath(), resultSummaries);
         Assertions.assertTrue(overallStatus);
     }
 

--- a/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
+++ b/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
@@ -14,7 +14,7 @@ public class MarkdownReportGenerator {
 
     public static void generateAndWriteMarkdownReport(String project, String path, List<TestResultSummary> testResultSummaryList) {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("## Project : `" + project + "`");
+        stringBuilder.append("## Project : " + project);
 
         testResultSummaryList.forEach(testResultSummary ->
         {
@@ -28,8 +28,9 @@ public class MarkdownReportGenerator {
                             testResultSummary.getFailingCasesCount() + "       | " +
                             (testResultSummary.getPassingCasesCount() + testResultSummary.getFailingCasesCount()) + "    |")
                     .append("\n\n")
-                    .append("### Failing cases").append("\n");
-
+                    .append("<details>\n" +
+                            "<summary>Failing cases</summary>\n" +
+                            "\n");
             if (testResultSummary.getFailingCasesCount() == 0) {
                 stringBuilder.append("There are no failing cases.");
             } else {
@@ -37,6 +38,9 @@ public class MarkdownReportGenerator {
                     stringBuilder.append("- " + failingCaseId).append("\n");
                 });
             }
+            stringBuilder.append("\n").append("</details>").append("\n")
+                    .append(generatePieChart(testResultSummary));
+
         });
         writeFile(project + "-summary", stringBuilder.toString(), path);
     }
@@ -59,5 +63,19 @@ public class MarkdownReportGenerator {
         } catch (IOException e) {
             System.out.println("Failed to write markdown report.");
         }
+    }
+
+    private static String generatePieChart(TestResultSummary testResultSummary) {
+        StringBuilder pieChartBuilder = new StringBuilder();
+        pieChartBuilder.append("<details>").append("\n")
+                .append("<summary>Status Chart</summary>").append("\n\n")
+                .append("```mermaid\n" +
+                        "%%{init: {'theme': 'default', 'themeVariables': {'pie1': '#238636', 'pie2': '#da3633'}}}%%\n" +
+                        "pie title Status Chart\n" +
+                        "    \"Passing\" : " + testResultSummary.getFailingCasesCount() + "\n" +
+                        "    \"Failing\" : " + testResultSummary.getPassingCasesCount() + "\n" +
+                        "```").append("\n")
+                .append("</details>").append("\n\n");
+        return pieChartBuilder.toString();
     }
 }

--- a/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
+++ b/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
@@ -41,6 +41,15 @@ public class MarkdownReportGenerator {
         writeFile(project + "-summary", stringBuilder.toString(), path);
     }
 
+    public static void generateReportForSkippedTest(String project, String path) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("## Project : `" + project + "`")
+                .append("\n\n")
+                .append("Not running tests as Agent is not connected.")
+                .append("\n\n");
+        writeFile(project + "-summary", stringBuilder.toString(), path);
+    }
+
     private static void writeFile(String filename, String contents, String path) {
         try {
             File file = new File(path + filename + ".md");

--- a/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
+++ b/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
@@ -72,8 +72,8 @@ public class MarkdownReportGenerator {
                 .append("```mermaid\n" +
                         "%%{init: {'theme': 'default', 'themeVariables': {'pie1': '#238636', 'pie2': '#da3633'}}}%%\n" +
                         "pie title Status Chart\n" +
-                        "    \"Passing\" : " + testResultSummary.getFailingCasesCount() + "\n" +
-                        "    \"Failing\" : " + testResultSummary.getPassingCasesCount() + "\n" +
+                        "    \"Passing\" : " + testResultSummary.getPassingCasesCount() + "\n" +
+                        "    \"Failing\" : " + testResultSummary.getFailingCasesCount() + "\n" +
                         "```").append("\n")
                 .append("</details>").append("\n\n");
         return pieChartBuilder.toString();

--- a/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
+++ b/src/test/java/io/unlogged/autoexecutor/report/MarkdownReportGenerator.java
@@ -1,0 +1,54 @@
+package io.unlogged.autoexecutor.report;
+
+import io.unlogged.autoexecutor.testutils.entity.TestResultSummary;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+public class MarkdownReportGenerator {
+
+    private String filename;
+
+    public static void generateAndWriteMarkdownReport(String project, String path, List<TestResultSummary> testResultSummaryList) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("## Project : `" + project + "`");
+
+        testResultSummaryList.forEach(testResultSummary ->
+        {
+            stringBuilder
+                    .append("\n\n")
+                    .append("### Mode : " + testResultSummary.getMode()).append("\n\n")
+                    .append("| Status   | Passing | Failing | Total |").append("\n")
+                    .append("|----------|---------|---------|-------|").append("\n")
+                    .append("| " + (testResultSummary.getFailingCasesCount() == 0 ? "Pass" : "Fail") + "     | " +
+                            testResultSummary.getPassingCasesCount() + "       | " +
+                            testResultSummary.getFailingCasesCount() + "       | " +
+                            (testResultSummary.getPassingCasesCount() + testResultSummary.getFailingCasesCount()) + "    |")
+                    .append("\n\n")
+                    .append("### Failing cases").append("\n");
+
+            if (testResultSummary.getFailingCasesCount() == 0) {
+                stringBuilder.append("There are no failing cases.");
+            } else {
+                testResultSummary.getFailingCases().forEach(failingCaseId -> {
+                    stringBuilder.append("- " + failingCaseId).append("\n");
+                });
+            }
+        });
+        writeFile(project + "-summary", stringBuilder.toString(), path);
+    }
+
+    private static void writeFile(String filename, String contents, String path) {
+        try {
+            File file = new File(path + filename + ".md");
+            BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+            writer.write(contents);
+            writer.close();
+        } catch (IOException e) {
+            System.out.println("Failed to write markdown report.");
+        }
+    }
+}

--- a/src/test/java/io/unlogged/autoexecutor/testutils/entity/TestConfig.java
+++ b/src/test/java/io/unlogged/autoexecutor/testutils/entity/TestConfig.java
@@ -1,0 +1,23 @@
+package io.unlogged.autoexecutor.testutils.entity;
+
+import java.net.URL;
+import java.util.TreeMap;
+
+public class TestConfig {
+
+    private String projectId;
+    private TreeMap<String, URL> modeToResourceMap;
+
+    public TestConfig(String projectId, TreeMap<String, URL> modeToResourceMap) {
+        this.projectId = projectId;
+        this.modeToResourceMap = modeToResourceMap;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public TreeMap<String, URL> getModeToResourceMap() {
+        return modeToResourceMap;
+    }
+}

--- a/src/test/python/autoexecute_ci.py
+++ b/src/test/python/autoexecute_ci.py
@@ -14,19 +14,19 @@ def autoexecute_target(target):
     elif (target.buildSystem == buildSystem.GRADLE):
         target.modify_gradle(sdk_version)
 
-    docker_up_cmd = "cd " + target.test_repo_name + " && docker-compose -f conf/docker-compose.yml up -d"
+    docker_up_cmd = "cd " + target.test_repo_name + " && docker compose -f conf/docker-compose.yml up -d"
     os.system(docker_up_cmd)
 
     proc = subprocess.Popen(["docker ps -a"], stdout=subprocess.PIPE, shell=True)
     (out_stream, err_stream) = proc.communicate()
 
     # wait till project has started
-    time.sleep(120)
+    time.sleep(140)
 
     test_command = "mvn test -Dtest=AutoExecutorCITest#"+target.autoexecutor_test_method
     status = os.system(test_command)
 
-    docker_down_cmd = "cd " + target.test_repo_name + " && docker-compose -f conf/docker-compose.yml down"
+    docker_down_cmd = "cd " + target.test_repo_name + " && docker compose -f conf/docker-compose.yml down"
     os.system(docker_down_cmd)
     os.system("rm -rf " + target.test_repo_name)
 

--- a/src/test/python/replay_target.py
+++ b/src/test/python/replay_target.py
@@ -16,7 +16,7 @@ def replay_target (target):
 		target.modify_gradle(sdk_version)
 	
 	# server start
-	docker_up_cmd = "cd " + target.test_repo_name + " && docker-compose -f conf/docker-compose.yml up -d"
+	docker_up_cmd = "cd " + target.test_repo_name + " && docker compose -f conf/docker-compose.yml up -d"
 	val_1 = os.system(docker_up_cmd)
 
 	proc = subprocess.Popen(["docker ps -a"], stdout=subprocess.PIPE, shell=True)
@@ -38,7 +38,7 @@ def replay_target (target):
 
 	# assert and clean repo
 	local_error_state = target.check_replay()
-	docker_down_cmd = "cd " + target.test_repo_name + " && docker-compose -f conf/docker-compose.yml down"
+	docker_down_cmd = "cd " + target.test_repo_name + " && docker compose -f conf/docker-compose.yml down"
 	os.system(docker_down_cmd)
 	os.system("rm -rf " + target.test_repo_name)
 	return local_error_state


### PR DESCRIPTION
AutoExecutor reports will now be shown in the following format for each test resource (excel sheet - project + mode)

## Project : `project-name`

### Mode : `Integration/Unit`

| Status   | Passing | Failing | Total |
|----------|---------|---------|-------|
| `Pass/Fail`     | `Pass count`       | `Fail count`       | `Total Count`    |

<details>
<summary>Failing cases</summary>

- Failing case Id 1
- Failing case Id 2
...

</details>
<details>
<summary>Status Chart</summary>

```mermaid
%%{init: {'theme': 'default', 'themeVariables': {'pie1': '#238636', 'pie2': '#da3633'}}}%%
pie title Status Chart
    "Failing" : 27
    "Passing" : 415
```
</details>

Note: Charts don't render on the job summary view, but can be viewed from downloaded test reports.