### PR TITLE
Log nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,7 @@
 
 ## SDK v0.7.3
 - Fixed an issue where some methods when invoked were creating two test candidates. This was happening for methods where a synthetic method was emitted by the Java compiler.
+
+## SDK v0.7.4
+- The SDK now comes with LogNothing mode. The SDK in this mode logs nothing, but direct invoke still works.
+- There are now better defualt modes for SDK. When annotation is not set then it runs in LogNothing mode. When annotation is set but mode is not defined then it runs in LogAll mode.

--- a/src/main/java/io/unlogged/UnloggedMode.java
+++ b/src/main/java/io/unlogged/UnloggedMode.java
@@ -1,6 +1,7 @@
 package io.unlogged;
 
 public enum UnloggedMode {
+	LogNothing,
     LogAll,
     LogAnnotatedOnly,
     LogAnnotatedWithChildren

--- a/src/main/java/io/unlogged/core/PostCompiler.java
+++ b/src/main/java/io/unlogged/core/PostCompiler.java
@@ -21,20 +21,23 @@
  */
 package io.unlogged.core;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.unlogged.UnloggedMode;
 import io.unlogged.core.bytecode.ProbeInstrumenter;
 import io.unlogged.core.javac.HandlerLibrary;
 import io.unlogged.core.processor.UnloggedProcessorConfig;
 import io.unlogged.weaver.DataInfoProvider;
 
-import java.io.*;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public final class PostCompiler {
     private static List<PostCompilerTransformation> transformations;
-
-    ;
 
     private PostCompiler() {/* prevent instantiation*/}
 
@@ -43,8 +46,18 @@ public final class PostCompiler {
 			DiagnosticsReceiver diagnostics,
             OutputStream classWeaveOutputStream,
 			DataInfoProvider dataInfoProvider,
-			UnloggedProcessorConfig unloggedProcessorConfig) {
-        if (System.getProperty("unlogged.disablePostCompiler", null) != null) return original;
+			UnloggedProcessorConfig unloggedProcessorConfig) 
+		{
+
+
+        if (System.getProperty("unlogged.disablePostCompiler", null) != null) {
+			return original;
+		}
+		else if (unloggedProcessorConfig.getUnloggedMode() == UnloggedMode.LogNothing) {
+			return original;
+		}
+
+
         init(diagnostics, unloggedProcessorConfig);
         byte[] previous = original;
         for (PostCompilerTransformation transformation : transformations) {

--- a/src/main/java/io/unlogged/core/PostCompiler.java
+++ b/src/main/java/io/unlogged/core/PostCompiler.java
@@ -53,10 +53,6 @@ public final class PostCompiler {
         if (System.getProperty("unlogged.disablePostCompiler", null) != null) {
 			return original;
 		}
-		else if (unloggedProcessorConfig.getUnloggedMode() == UnloggedMode.LogNothing) {
-			return original;
-		}
-
 
         init(diagnostics, unloggedProcessorConfig);
         byte[] previous = original;

--- a/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
+++ b/src/main/java/io/unlogged/core/bytecode/ClassTransformer.java
@@ -191,7 +191,7 @@ public class ClassTransformer extends ClassVisitor {
             className = name.substring(index + 1);
         }
 
-		this.addHashMap = ProbeFlagUtil.getAddHashMap(access);
+		this.addHashMap = ProbeFlagUtil.getAddHashMap(this.unloggedProcessorConfig, access);
         super.visit(version, access, name, signature, superName, interfaces);
     }
 
@@ -233,7 +233,7 @@ public class ClassTransformer extends ClassVisitor {
 		
 		// calculate probe flag at method level
 		Boolean alwaysProbeMethodFlag = !this.addHashMap || ProbeFlagUtil.getAlwaysProbeMethodFlag(name, access, desc);
-		Boolean neverProbeMethodFlag = ProbeFlagUtil.getNeverProbeMethodFlag(name, access);
+		Boolean neverProbeMethodFlag = ProbeFlagUtil.getNeverProbeMethodFlag(this.unloggedProcessorConfig, name, access);
 
 		if (name.equals("<clinit>")) {
 			// early exit for clinit. It is already defined in class with initial method

--- a/src/main/java/io/unlogged/core/processor/UnloggedProcessor.java
+++ b/src/main/java/io/unlogged/core/processor/UnloggedProcessor.java
@@ -53,6 +53,7 @@ public class UnloggedProcessor extends AbstractProcessor {
     private JavacTransformer transformer;
     private JavacFiler javacFiler;
 	private UnloggedProcessorConfig unloggedProcessorConfig = new UnloggedProcessorConfig(1, UnloggedLoggingLevel.COUNTER, UnloggedMode.LogAll);
+	private boolean parsed = false;
 
 
     public UnloggedProcessor() {
@@ -372,6 +373,7 @@ public class UnloggedProcessor extends AbstractProcessor {
 
 
 		for (Element element : roundEnv.getElementsAnnotatedWith(Unlogged.class)) {
+			this.parsed = true;
 			Unlogged unlogged = element.getAnnotation(Unlogged.class);
 			
 			// setup unloggedProcessorConfig
@@ -387,7 +389,14 @@ public class UnloggedProcessor extends AbstractProcessor {
         }
 
         Set<? extends Element> annotatedClasses = roundEnv.getElementsAnnotatedWith(Unlogged.class);
-        if (annotatedClasses.size() > 1) {
+
+		if (annotatedClasses.isEmpty() && !this.parsed) {
+			this.parsed = true;
+			this.unloggedProcessorConfig.setUnloggedMode(UnloggedMode.LogNothing);
+			return false;
+		}
+
+        else if (annotatedClasses.size() > 1) {
             throw new RuntimeException("More than 1 class annotated with @Unlogged annotation. Only the entry point " +
                     "method should be annotated with @Unlogged annotation: [" +
                     annotatedClasses.stream()

--- a/src/main/java/io/unlogged/core/processor/UnloggedProcessor.java
+++ b/src/main/java/io/unlogged/core/processor/UnloggedProcessor.java
@@ -372,7 +372,8 @@ public class UnloggedProcessor extends AbstractProcessor {
         if (System.getProperty("unlogged.disable", null) != null) return false;
 
 
-		for (Element element : roundEnv.getElementsAnnotatedWith(Unlogged.class)) {
+		Set<? extends Element> annotatedClasses = roundEnv.getElementsAnnotatedWith(Unlogged.class);
+		for (Element element : annotatedClasses) {
 			this.parsed = true;
 			Unlogged unlogged = element.getAnnotation(Unlogged.class);
 			
@@ -388,15 +389,13 @@ public class UnloggedProcessor extends AbstractProcessor {
             return false;
         }
 
-        Set<? extends Element> annotatedClasses = roundEnv.getElementsAnnotatedWith(Unlogged.class);
-
 		if (annotatedClasses.isEmpty() && !this.parsed) {
+			// no class is annotated with Unlogged
+			// set log mode as LogNothing
 			this.parsed = true;
 			this.unloggedProcessorConfig.setUnloggedMode(UnloggedMode.LogNothing);
-			return false;
 		}
-
-        else if (annotatedClasses.size() > 1) {
+		else if (annotatedClasses.size() > 1) {
             throw new RuntimeException("More than 1 class annotated with @Unlogged annotation. Only the entry point " +
                     "method should be annotated with @Unlogged annotation: [" +
                     annotatedClasses.stream()

--- a/src/main/java/io/unlogged/util/ProbeFlagUtil.java
+++ b/src/main/java/io/unlogged/util/ProbeFlagUtil.java
@@ -2,18 +2,25 @@ package io.unlogged.util;
 
 import org.objectweb.asm.Opcodes;
 
+import io.unlogged.UnloggedMode;
+import io.unlogged.core.processor.UnloggedProcessorConfig;
+
 public class ProbeFlagUtil {
 
-	public static boolean getAddHashMap(int access) {
+	public static boolean getAddHashMap(UnloggedProcessorConfig unloggedProcessorConfig, int access) {
 		// TODO: remove this filter
 		// decide if a Hashmap is to be added in static call of the class
 		// always probe a default method in interface, because we cannot add a hashmap to the interface
 
-		if (((access & Opcodes.ACC_INTERFACE) != 0)
+		if (unloggedProcessorConfig.getUnloggedMode() == UnloggedMode.LogNothing) {
+			return false;
+		}
+		else if (((access & Opcodes.ACC_INTERFACE) != 0)
 			|| ((access & Opcodes.ACC_ENUM) != 0)){
 			// do not add a hash map
 			return false;
 		}
+
 		return true;
 	}
 
@@ -30,9 +37,12 @@ public class ProbeFlagUtil {
 		return false;
 	}
 
-	public static Boolean getNeverProbeMethodFlag (String methodName, int access) {
+	public static Boolean getNeverProbeMethodFlag (UnloggedProcessorConfig unloggedProcessorConfig, String methodName, int access) {
 
-		if (methodName.equals("equals")
+		if (unloggedProcessorConfig.getUnloggedMode() == UnloggedMode.LogNothing) {
+			return true;
+		}
+		else if (methodName.equals("equals")
 			|| methodName.equals("hashCode")
 			|| methodName.equals("onNext")
 			|| methodName.equals("onSubscribe")


### PR DESCRIPTION
This PR adds LogNothing logging mode to SDK, and more user intuitive default modes. When SDK is set to LogNothing mode, the bytecode injection will be blocked at ClassTransformer layer itself, and no probes will be injected. Though the static methods are still injected, which is needed for Direct Invoke.

### Sanity Testing

1. No annotation is defined
- SDK is set to LogNothing mode
- [video demo](https://drive.google.com/file/d/1twi68aNsjC2I-8sp7Vggh8PsxDMzT3Ur/view?usp=sharing)

2. Annotation is defined without mode
- SDK is set to LogAll mode
- [video demo](https://drive.google.com/file/d/17cshtKPvmABJxSz2iuZiycS5yzxEi3vu/view?usp=sharing)

3. Annotation is defined with LogAll
- [video demo](https://drive.google.com/file/d/1VIW4UXs6hZVIwptcr3CAVYIE_RrN3Y1J/view?usp=sharing)

4. Annotation is defined with LogNothing
- [video demo](https://drive.google.com/file/d/1n37a0V3stEXAjb2JW02Xk-RS_0PpIcxw/view?usp=sharing)


## CI pipeline
1. compile target pipeline runs
2. replay pipeline
#### main branch: 
- usmd java-17: 6/6
- usmd java-8: 25/30
- usmd java-21: 0/0
- webflux java-8: 60/79
- webflux java-11: 60/79
- webflux java-21: 19/22
- weblux java-17: 98/140
- usmd java-17: 167/178

#### log_nothing branch:
- usmd java-17: 6/6
- usmd java-8: 25/30
- usmd java-21: 0/0
- webflux java-8: 60/79
- usmd java-11: 60/79
- webflux java-21: 19/22
- webflux java-17: 102/140 [4 tests seem flaky]
- usmd java-17: 167/178

3. auto-executor pipeline
#### main branch
![Screenshot 2024-08-27 at 12 15 33 PM](https://github.com/user-attachments/assets/f93066b9-6048-4609-a29d-1aedbddf3b5a)

#### log_nothing branch
![Screenshot 2024-08-27 at 12 16 12 PM](https://github.com/user-attachments/assets/cf98244e-c9b3-40d1-bb29-76d6acb8f4c5)
